### PR TITLE
Dependency hell

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,8 @@ opentracing==1.3.0
 opentracing_instrumentation==2.4.3
 psycopg2==2.7.5
 pytest==3.5.1
-redis==3.0.1
+redis==3.2.0
 requests==2.21.0
 setproctitle==1.1.10 # used by celery to change process name
 structlog==18.2.0
+tornado==4.5.3


### PR DESCRIPTION
1. Fix Tornado version. Tornado released v6 on 1st March, which removes some deprecated APIs that we use. This caused things to crash.
2. Update Redis to 3.2.0.