### PR TITLE
Add support for external postgresql

### DIFF
--- a/deployment/entity-service/templates/configmap.yaml
+++ b/deployment/entity-service/templates/configmap.yaml
@@ -12,7 +12,13 @@ data:
   REDIS_SERVER: {{ .Values.redis.server }}
   REDIS_USE_SENTINEL: {{ .Values.redis.use_sentinel }}
   {{ end }}
-  DATABASE_SERVER: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
+  {{ if .Values.provision.postgresql }}
+  DATABASE_SERVER: {{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}
+  {{ else }}
+  DATABASE_SERVER: {{.Values.postgresql.nameOverride }}
+  {{ end }} 
+  DATABASE_USER: {{ .Values.postgresql.postgresqlUsername }}
+  DATABASE: {{ .Values.postgresql.postgresqlDatabase }} 
   DEBUG: {{ .Values.workers.debug | quote }}
   ENTITY_MATCH_THRESHOLD: {{ .Values.workers.MATCH_THRESHOLD | quote }}
   SMALL_COMPARISON_CHUNK_SIZE: {{ .Values.workers.SMALL_COMPARISON_CHUNK_SIZE | quote }}

--- a/deployment/entity-service/templates/init-db-job.yaml
+++ b/deployment/entity-service/templates/init-db-job.yaml
@@ -24,9 +24,10 @@ spec:
         image: {{ .Values.api.dbinit.image.repository }}:{{ .Values.api.dbinit.image.tag }}
         resources:
 {{ toYaml .Values.api.dbinit.resources | indent 10 }}
+        envFrom:
+          - configMapRef:
+              name: {{ template "es.fullname" . }} 
         env:
-          - name: DATABASE_SERVER
-            value: "{{ .Release.Name }}-{{ .Values.postgresql.nameOverride }}"
           - name: DATABASE_PASSWORD
             valueFrom:
               secretKeyRef:


### PR DESCRIPTION
This replaces PR #342 from @Muelsy - for security reasons we don't run tests on our internal infrastructure from external contributors.

> I needed to use an external postgres provider for my test cluster, which meant I had to modify some templates. This PR enables users to connect the entity service to a a postgres server of their choosing. Pretty basic - if/else condition to see if postgres is being provisioned, if it is then set the database server to {{.Release.Name }}-{{ .Values.postgresql.nameOverride}}. If provisioning is disabled, use {{ .Values.postgresql.nameOverride }} instead.
> 
> This is working on my home cluster, and it passed the integration tests.

(@nbgl I've reviewed the changes but I don't want to approve my own PR.)