### PR TITLE
Configurable logging

### DIFF
--- a/backend/entityservice/async_worker.py
+++ b/backend/entityservice/async_worker.py
@@ -5,7 +5,7 @@ from celery.signals import task_prerun
 import structlog
 
 from entityservice.settings import Config
-
+from entityservice.logger_setup import setup_structlog
 
 celery = Celery('tasks',
                 broker=Config.CELERY_BROKER_URL,
@@ -21,31 +21,15 @@ celery.conf.worker_prefetch_multiplier = Config.CELERYD_PREFETCH_MULTIPLIER
 celery.conf.worker_max_tasks_per_child = Config.CELERYD_MAX_TASKS_PER_CHILD
 
 
-structlog.configure(
-    processors=[
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.dev.ConsoleRenderer()
-    ],
-    context_class=structlog.threadlocal.wrap_dict(dict),
-    logger_factory=structlog.stdlib.LoggerFactory(),
-)
-
-# Set logging level of other python libraries that we use
-logging.getLogger('celery').setLevel(logging.WARNING)
-logging.getLogger('jaeger_tracing').setLevel(logging.WARNING)
-
 # Set up our logging
-logger = structlog.wrap_logger(logging.getLogger('celery.es'))
+setup_structlog()
+logger = structlog.wrap_logger(logging.getLogger('entityservice.tasks'))
 if Config.DEBUG:
-    logging.getLogger('celery.es').setLevel(logging.DEBUG)
-    logging.getLogger('celery').setLevel(logging.INFO)
+    logging.getLogger('entityservice.tasks').setLevel(logging.DEBUG)
+    #logging.getLogger('celery').setLevel(logging.INFO)
 
 
-logger.info("Setting up celery worker")
+logger.info("Setting up entityservice worker")
 logger.debug("Debug logging enabled")
 
 

--- a/backend/entityservice/async_worker.py
+++ b/backend/entityservice/async_worker.py
@@ -24,11 +24,6 @@ celery.conf.worker_max_tasks_per_child = Config.CELERYD_MAX_TASKS_PER_CHILD
 # Set up our logging
 setup_structlog()
 logger = structlog.wrap_logger(logging.getLogger('entityservice.tasks'))
-if Config.DEBUG:
-    logging.getLogger('entityservice.tasks').setLevel(logging.DEBUG)
-    #logging.getLogger('celery').setLevel(logging.INFO)
-
-
 logger.info("Setting up entityservice worker")
 logger.debug("Debug logging enabled")
 

--- a/backend/entityservice/default_logging.yaml
+++ b/backend/entityservice/default_logging.yaml
@@ -55,7 +55,7 @@ loggers:
     propagate: no
 
   entityservice.database.util:
-    level: WARN
+    level: WARNING
     propagate: no
 
   celery:
@@ -63,7 +63,7 @@ loggers:
     propogate: yes
 
   jaeger_tracing:
-    level: WARN
+    level: WARNING
     propogate: no
 
   werkzeug:

--- a/backend/entityservice/errors.py
+++ b/backend/entityservice/errors.py
@@ -1,4 +1,8 @@
 
+class InvalidConfiguration(ValueError):
+    """Config wasn't as expected"""
+
+
 class DatabaseInconsistent(Exception):
     pass
 

--- a/backend/entityservice/logger_setup.py
+++ b/backend/entityservice/logger_setup.py
@@ -1,0 +1,90 @@
+import os
+import logging.config
+import structlog
+
+import yaml
+
+
+def setup_logging(
+    default_path='logging.yaml',
+    default_level='INFO',
+    env_key='LOG_CFG'
+):
+    """
+    Setup logging configuration
+    """
+    path = os.path.dirname(os.path.abspath(__file__)) + '/' + default_path
+    value = os.getenv(env_key, None)
+    if value:
+        path = value
+    if os.path.exists(path):
+        with open(path, 'rt') as f:
+            config = yaml.safe_load(f.read())
+        logging.config.dictConfig(config)
+    else:
+        print("YAML file doesn't exist")
+        default_level = _str_to_level(default_level)
+        logging.basicConfig(level=default_level)
+
+    # Configure Structlog wrapper for client use
+    setup_structlog()
+
+
+def setup_structlog():
+    structlog.configure(
+        processors=[
+            structlog.stdlib.filter_by_level,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt='iso'),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+
+            # Uncomment ONE Renderer:
+            #structlog.processors.KeyValueRenderer(),
+            #structlog.processors.JSONRenderer(),
+            structlog.dev.ConsoleRenderer()
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+class StdErrFilter(logging.Filter):
+    """
+    Filter for the stderr stream
+    Doesn't print records below ERROR to stderr to avoid dupes
+    """
+    def filter(self, record):
+        return 0 if record.levelno < logging.ERROR else 1
+
+
+class StdOutFilter(logging.Filter):
+    """
+    Filter for the stdout stream
+    Doesn't print records above WARNING to stdout to avoid dupes
+    """
+    def filter(self, record):
+        return 1 if record.levelno < logging.ERROR else 0
+
+
+def _str_to_level(lvl):
+    """
+    Convenience function to convert a log level string to the numeric rep
+    """
+    lvl = lvl.strip().lower()
+    if lvl == 'warn':
+        return logging.WARNING
+    elif lvl == 'info':
+        return logging.INFO
+    elif lvl == 'debug':
+        return logging.DEBUG
+    elif lvl == 'critical':
+        return logging.CRITICAL
+    elif lvl == 'error':
+        return logging.ERROR
+    else:
+        return logging.INFO

--- a/backend/entityservice/logger_setup.py
+++ b/backend/entityservice/logger_setup.py
@@ -19,17 +19,14 @@ def setup_logging(
         with open(path, 'rt') as f:
             config = yaml.safe_load(f)
         logging.config.dictConfig(config)
-        msg = "Loaded logging config from file"
     except yaml.YAMLError as e:
-        msg = "Parsing YAML logging config failed"
-        raise InvalidConfiguration(msg) from e
+        raise InvalidConfiguration("Parsing YAML logging config failed") from e
     except FileNotFoundError as e:
-        msg = "Logging config YAML file doesn't exist. Falling back to defaults"
-        raise InvalidConfiguration(msg) from e
+        raise InvalidConfiguration("Logging config YAML file doesn't exist. Falling back to defaults") from e
 
     # Configure Structlog wrapper for client use
     setup_structlog()
-    logging.info(msg)
+    logging.info("Loaded logging config from file")
 
 
 def setup_structlog():

--- a/backend/entityservice/logger_setup.py
+++ b/backend/entityservice/logger_setup.py
@@ -17,7 +17,7 @@ def setup_logging(
 
     try:
         with open(path, 'rt') as f:
-            config = yaml.safe_load(f.read())
+            config = yaml.safe_load(f)
         logging.config.dictConfig(config)
     except FileNotFoundError:
         print("Logging config YAML file doesn't exist. Falling back to defaults")

--- a/backend/entityservice/logger_setup.py
+++ b/backend/entityservice/logger_setup.py
@@ -67,10 +67,10 @@ class StdErrFilter(logging.Filter):
 class StdOutFilter(logging.Filter):
     """
     Filter for the stdout stream
-    Doesn't print records above WARNING to stdout to avoid dupes
+    Doesn't print records at ERROR or above to stdout to avoid dupes
     """
     def filter(self, record):
-        return record.levelno <= logging.WARNING
+        return record.levelno < logging.ERROR
 
 
 def _str_to_level(lvl):

--- a/backend/entityservice/logging.yaml
+++ b/backend/entityservice/logging.yaml
@@ -1,0 +1,76 @@
+---
+version: 1
+disable_existing_loggers: False
+formatters:
+  simple:
+    format: "%(asctime)-10s %(message)s"
+    datefmt: "%H:%M:%S"
+  file:
+    format: "%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s"
+filters:
+  stderr_filter:
+    (): entityservice.logger_setup.StdErrFilter
+  stdout_filter:
+    (): entityservice.logger_setup.StdOutFilter
+
+handlers:
+  stdout:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    filters: [stdout_filter]
+    stream: ext://sys.stdout
+
+  stderr:
+    class: logging.StreamHandler
+    level: ERROR
+    formatter: simple
+    filters: [stderr_filter]
+    stream: ext://sys.stderr
+
+  info_file_handler:
+    class: logging.handlers.RotatingFileHandler
+    level: INFO
+    formatter: file
+    filename: info.log
+    maxBytes: 10485760 # 10MB
+    backupCount: 20
+    encoding: utf8
+
+  error_file_handler:
+    class: logging.handlers.RotatingFileHandler
+    level: ERROR
+    formatter: file
+    filename: errors.log
+    maxBytes: 10485760 # 10MB
+    backupCount: 20
+    encoding: utf8
+
+loggers:
+  entityservice:
+    level: DEBUG
+    propagate: yes
+
+  entityservice.tasks:
+    level: DEBUG
+    propagate: no
+
+  entityservice.database.util:
+    level: WARN
+    propagate: no
+
+  celery:
+    level: INFO
+    propogate: yes
+
+  jaeger_tracing:
+    level: WARN
+    propogate: no
+
+  werkzeug:
+    level: WARN
+    propogate: no
+
+root:
+  level: INFO
+  handlers: [stdout, stderr, info_file_handler, error_file_handler]

--- a/backend/entityservice/logging.yaml
+++ b/backend/entityservice/logging.yaml
@@ -3,8 +3,7 @@ version: 1
 disable_existing_loggers: False
 formatters:
   simple:
-    format: "%(asctime)-10s %(message)s"
-    datefmt: "%H:%M:%S"
+    format: "%(message)s"
   file:
     format: "%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s"
 filters:

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -20,9 +20,6 @@ class Config(object):
     LOGFILE = os.getenv("LOGFILE")
     LOG_HTTP_HEADER_FIELDS = os.getenv("LOG_HTTP_HEADER_FIELDS")
 
-    fileFormat = logging.Formatter('%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s')
-    consoleFormat = logging.Formatter('%(asctime)-10s %(levelname)-8s %(message)s',
-                                      datefmt="%H:%M:%S")
 
     REDIS_SERVER = os.getenv('REDIS_SERVER', 'redis')
     REDIS_PASSWORD = os.getenv('REDIS_PASSWORD', '')

--- a/backend/entityservice/verbose_logging.yaml
+++ b/backend/entityservice/verbose_logging.yaml
@@ -1,0 +1,75 @@
+---
+version: 1
+disable_existing_loggers: False
+formatters:
+  simple:
+    format: "%(message)s"
+  file:
+    format: "%(asctime)-15s %(name)-12s %(levelname)-8s: %(message)s"
+filters:
+  stderr_filter:
+    (): entityservice.logger_setup.StdErrFilter
+  stdout_filter:
+    (): entityservice.logger_setup.StdOutFilter
+
+handlers:
+  stdout:
+    class: logging.StreamHandler
+    level: DEBUG
+    formatter: simple
+    filters: [stdout_filter]
+    stream: ext://sys.stdout
+
+  stderr:
+    class: logging.StreamHandler
+    level: ERROR
+    formatter: simple
+    filters: [stderr_filter]
+    stream: ext://sys.stderr
+
+  info_file_handler:
+    class: logging.handlers.RotatingFileHandler
+    level: INFO
+    formatter: file
+    filename: info.log
+    maxBytes: 10485760 # 10MB
+    backupCount: 20
+    encoding: utf8
+
+  error_file_handler:
+    class: logging.handlers.RotatingFileHandler
+    level: ERROR
+    formatter: file
+    filename: errors.log
+    maxBytes: 10485760 # 10MB
+    backupCount: 20
+    encoding: utf8
+
+loggers:
+  entityservice:
+    level: DEBUG
+    propagate: yes
+
+  entityservice.tasks:
+    level: DEBUG
+    propagate: no
+
+  entityservice.database.util:
+    level: WARNING
+    propagate: no
+
+  celery:
+    level: INFO
+    propogate: yes
+
+  jaeger_tracing:
+    level: WARN
+    propogate: no
+
+  werkzeug:
+    level: WARNING
+    propogate: no
+
+root:
+  level: INFO
+  handlers: [stdout, stderr, info_file_handler, error_file_handler]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ anonlink==0.11.2
 bitmath==1.3.1.2
 celery==4.2.1
 clkhash==0.12.0
-colorama==0.4.0 # required for structlog
+colorama==0.4.1 # required for structlog
 connexion==1.4
 Flask-Opentracing==0.2.0
 Flask==1.0.2
@@ -17,6 +17,7 @@ opentracing==1.3.0
 opentracing_instrumentation==2.4.3
 psycopg2==2.7.5
 pytest==3.5.1
+PyYAML==3.12
 redis==3.2.0
 requests==2.21.0
 setproctitle==1.1.10 # used by celery to change process name


### PR DESCRIPTION
Instead of having the logging config all hardcoded we can read from a yaml file.

Addresses issue #323.

Fixes a few issues with logging too (e.g. including the timestamp twice).