### PR TITLE
Use Anonlink chunking API

### DIFF
--- a/backend/entityservice/database/insertions.py
+++ b/backend/entityservice/database/insertions.py
@@ -179,18 +179,6 @@ def set_project_encoding_size(db, project_id, encoding_size):
         cur.execute(sql_query, [encoding_size, project_id])
 
 
-def update_run_chunk(db, resource_id, chunk_size):
-    sql_query = """
-        UPDATE runs
-        SET
-          chunk_size = %s
-        WHERE
-          run_id = %s
-        """
-    with db.cursor() as cur:
-        cur.execute(sql_query, [chunk_size, resource_id])
-
-
 def update_run_set_started(db, run_id):
     with db.cursor() as cur:
         sql_query = """

--- a/backend/entityservice/init-db-schema.sql
+++ b/backend/entityservice/init-db-schema.sql
@@ -64,8 +64,6 @@ CREATE TABLE runs (
 
   threshold      double precision NOT NULL,
 
-  chunk_size     BIGINT           NOT NULL DEFAULT -1,
-
   state          RUNSTATE         NOT NULL,
   stage          SMALLINT  DEFAULT 1,
   type           TEXT             NOT NULL,

--- a/backend/entityservice/serialization.py
+++ b/backend/entityservice/serialization.py
@@ -179,9 +179,14 @@ def get_similarity_scores(filename):
 def get_chunk_from_object_store(chunk_info, encoding_size=128):
     mc = connect_to_object_store()
     bit_packed_element_size = binary_format(encoding_size).size
-    chunk_length = chunk_info[2] - chunk_info[1]
+    chunk_range_start, chunk_range_stop = chunk_info['range']
+    chunk_length = chunk_range_stop - chunk_range_start
     chunk_bytes = bit_packed_element_size * chunk_length
-    chunk_stream = mc.get_partial_object(config.MINIO_BUCKET, chunk_info[0], bit_packed_element_size * chunk_info[1], chunk_bytes)
+    chunk_stream = mc.get_partial_object(
+        config.MINIO_BUCKET,
+        chunk_info['storeFilename'],
+        bit_packed_element_size * chunk_range_start,
+        chunk_bytes)
 
     chunk_data = binary_unpack_filters(chunk_stream, chunk_bytes, encoding_size)
 

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -64,13 +64,7 @@ class Config(object):
 
     # Number of comparisons per chunk. Default is to interpolate between the min
     # of 100M and the max size of 1B based on the JOB_SIZE parameters.
-    SMALL_COMPARISON_CHUNK_SIZE = int(os.getenv('SMALL_COMPARISON_CHUNK_SIZE', '100000000'))
-    LARGE_COMPARISON_CHUNK_SIZE = int(os.getenv('LARGE_COMPARISON_CHUNK_SIZE', '1000000000'))
-
-    # Anything smaller that this will use SMALL_COMPARISON_CHUNK_SIZE
-    SMALL_JOB_SIZE = int(os.getenv('SMALL_JOB_SIZE', '100000000'))
-    # Anything greater than this will use LARGE_COMPARISON_CHUNK_SIZE
-    LARGE_JOB_SIZE = int(os.getenv('LARGE_JOB_SIZE', '100000000000'))
+    CHUNK_SIZE_AIM = int(os.getenv('CHUNK_SIZE_AIM', '300000000'))
 
     # If there are more than 1M CLKS, don't cache them in redis
     MAX_CACHE_SIZE = int(os.getenv('MAX_CACHE_SIZE', '1000000'))
@@ -90,17 +84,3 @@ class Config(object):
     # Encoding size (in bytes)
     MIN_ENCODING_SIZE = int(os.getenv('MIN_ENCODING_SIZE', '1'))
     MAX_ENCODING_SIZE = int(os.getenv('MAX_ENCODING_SIZE', '1024'))
-
-    @classmethod
-    def get_task_chunk_size(cls, size, threshold):
-        # TODO use threshold to scale chunk size
-        if size <= cls.SMALL_JOB_SIZE:
-            return None
-        elif size >= cls.LARGE_JOB_SIZE:
-            chunk_size = cls.LARGE_COMPARISON_CHUNK_SIZE
-        else:
-            # Interpolate
-            gradient = (cls.LARGE_COMPARISON_CHUNK_SIZE - cls.SMALL_COMPARISON_CHUNK_SIZE) / (cls.LARGE_JOB_SIZE - cls.SMALL_JOB_SIZE)
-            chunk_size = cls.SMALL_COMPARISON_CHUNK_SIZE + size * gradient
-
-        return math.ceil(math.sqrt(chunk_size))

--- a/backend/entityservice/settings.py
+++ b/backend/entityservice/settings.py
@@ -62,8 +62,7 @@ class Config(object):
     CELERYD_MAX_TASKS_PER_CHILD = int(os.getenv('CELERYD_MAX_TASKS_PER_CHILD', '4'))
     CELERY_ACKS_LATE = os.getenv('CELERY_ACKS_LATE', 'false') == 'true'
 
-    # Number of comparisons per chunk. Default is to interpolate between the min
-    # of 100M and the max size of 1B based on the JOB_SIZE parameters.
+    # Number of comparisons per chunk (on average).
     CHUNK_SIZE_AIM = int(os.getenv('CHUNK_SIZE_AIM', '300000000'))
 
     # If there are more than 1M CLKS, don't cache them in redis


### PR DESCRIPTION
As part of this, we remove `chunk_size` from `runs` in the database as the chunk size no longer depends on the job size.